### PR TITLE
feat(home): add client-side search & make coin rows navigable

### DIFF
--- a/crypto-price-tracker/src/pages/Home/Home.jsx
+++ b/crypto-price-tracker/src/pages/Home/Home.jsx
@@ -1,12 +1,26 @@
-import React from 'react'
 import './Home.css'
-import { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { CoinContext } from '../../context/CoinContext.jsx'
+import { Link } from 'react-router-dom'
 
 const Home = () => {
 const {allCoin, currency} = useContext(CoinContext);
 const [displayCoin, setDisplayCoin] = useState([]);
 const [input, setInput] = useState('');
+const inputHandler = (event)=>{
+  setInput(event.target.value);
+  if(event.target.value === ""){
+    setDisplayCoin(allCoin);
+  }
+}
+
+const searchHandler = async (event)=>{
+  event.preventDefault();
+  const coins = await allCoin.filter((item)=>{
+    return item.name.toLowerCase().includes(input.toLowerCase())
+  })
+  setDisplayCoin(coins);
+}
 useEffect(()=>{
   setDisplayCoin(allCoin);
 },[allCoin])
@@ -15,8 +29,11 @@ useEffect(()=>{
       <div className="hero">
         <h1>Largest <br/> Crypto Marketplace</h1>
         <p>Welcome to the world's largest cryptocurrency marketplace. Sign up to explore more about cryptos.</p>
-        <form>
-          <input type="text" placeholder="Search for a coin..." />
+        <form onSubmit={searchHandler}>
+          <input onChange = {inputHandler} list='coinlist' value={input} type="text" placeholder="Search for a coin..." required/>
+          <datalist id='coinlist'>
+            {allCoin.map((item, index)=>(<option key={index} value={item.name}/>))}
+          </datalist>
           <button type="submit">Search</button>
         </form>
       </div>
@@ -30,7 +47,7 @@ useEffect(()=>{
         </div> 
  {
           displayCoin.slice(0,10).map((item, index)=>(
-            <div className="table-layout" key={index}>
+            <Link to={`/coin/${item.id}`} className="table-layout" key={index}>
               <p>{item.market_cap_rank}</p>
               <div>
                 <img src={item.image} alt="" />
@@ -40,7 +57,7 @@ useEffect(()=>{
               <p className={item.price_change_percentage_24h>0?"green":"red"}>
                 {Math.floor(item.price_change_percentage_24h*100)/100}</p>
               <p className='market-cap'>{currency.symbol} {item.market_cap.toLocaleString()}</p>
-            </div>
+            </Link>
           ))
         }
       </div>


### PR DESCRIPTION
Wires up a search/filter UI on the homepage and turns each coin row into a link, improving discoverability and navigation.  

- Enhance imports in `Home.jsx`:
  • Pull in `useContext`, `useEffect`, `useState` from React  
  • Import `CoinContext` for global coin data  
  • Bring in `Link` from `react-router-dom` for row navigation

- Implement search state logic:
  • Add `input` state and `inputHandler` to update search text and reset list when empty  
  • Add `searchHandler` (attached to `<form onSubmit>`), which filters `allCoin` by name (case-insensitive) and updates `displayCoin`

- Update markup in Hero section:
  • Replace standalone `<input>` with a `<form>` containing:  
    – `<input type="text"` bound to `input` state, with `list="coinlist"` for suggestions  
    – `<datalist id="coinlist">` rendering all coin names as `<option>`s  
    – `<button type="submit">Search</button>`

- Make table rows clickable:
  • Wrap each `.table-layout` `<div>` in `<Link to={\`/coin/${item.id}\`}>…</Link>` so clicking a row navigates to its detail page